### PR TITLE
chore(api): keep Swagger in dev and add TODOs (this is a test)

### DIFF
--- a/services/Bff/src/Bff.API/Program.cs
+++ b/services/Bff/src/Bff.API/Program.cs
@@ -18,8 +18,8 @@ var app = builder.Build();
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
-    // TODO: use microsofts openapi package introduced in dotnet 9 instead of swagger
-    // TODO: use scalar instead of swaggerui
+    // TODO: Use Microsoft's OpenAPI package introduced in .NET 9 instead of Swagger.
+    // TODO: Switch to using Scalar instead of SwaggerUI.
     app.UseSwagger();
     app.UseSwaggerUI();
 }

--- a/services/Bff/src/Bff.API/Program.cs
+++ b/services/Bff/src/Bff.API/Program.cs
@@ -18,6 +18,8 @@ var app = builder.Build();
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
+    // TODO: use microsofts openapi package introduced in dotnet 9 instead of swagger
+    // TODO: use scalar instead of swaggerui
     app.UseSwagger();
     app.UseSwaggerUI();
 }


### PR DESCRIPTION
Add TODO comments in Program.cs to remind developers to migrate
from the current Swagger/SwaggerUI setup to the newer .NET 9 OpenAPI
package and to consider using a scalar UI instead of SwaggerUI.

This clarifies next steps for improving the API tooling and ensures
the temporary Swagger usage remains enabled only in development.